### PR TITLE
change ordering of json object being created

### DIFF
--- a/Functions/EditSsisEnvironmentName.ps1
+++ b/Functions/EditSsisEnvironmentName.ps1
@@ -6,8 +6,8 @@ This executes the stored procedure "rename environment", effectively appending t
 .Description
 Before we re-write the values stored in an environment, we can effectively take a back up of the current environment by re-naming it.
 We can used the return name to revert this back to the original name if we need to rollback if a validation has failed
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -21,8 +21,8 @@ $ssisEnvironmentRename = Edit-SsisEnvironmentName -ssisPublishFilePath $thisSsis
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Position = 0, mandatory = $false)]
-        [string] $ssisPublishFilePath,
+        [Parameter(Position = 0, mandatory = $true)]
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -32,7 +32,7 @@ $ssisEnvironmentRename = Edit-SsisEnvironmentName -ssisPublishFilePath $thisSsis
         [Parameter(Position = 4, mandatory = $true)]
         [String] $ssisProjectLsn)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/GetSsisProjectLsn.ps1
+++ b/Functions/GetSsisProjectLsn.ps1
@@ -5,8 +5,8 @@ Function Get-SsisProjectLsn {
 Get latest project lsn. This is effectively the version number of the project.
 .Description
 useful for when we may need to rollback, this is the latest lsn for a given project.
-.Parameter ssisPublishFilePath 
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection 
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -19,14 +19,14 @@ Used in rollback process, but seeing as we're not currently using that process t
 
     [CmdletBinding()]
     param(
-        [Parameter(Position = 0, mandatory = $false)]
-        [string] $ssisPublishFilePath,
+        [Parameter(Position = 0, mandatory = $true)]
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
         [String] $ssisFolderName)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/ImportJson.ps1
+++ b/Functions/ImportJson.ps1
@@ -16,8 +16,8 @@ $ssisJson = Import-Json -path "C:\Users\SQLTraining\Documents\iscPublish.json"
     )
     try {
         $json = Get-Content -Raw -Path $path -Encoding UTF8 | ConvertFrom-Json
-        $json2 = Test-Json -jsonToTest $json
-        return $json2
+        $jsonTested = Test-Json -jsonToTest $json
+        return $jsonTested
     }
     catch {
         throw $_.Exception

--- a/Functions/InvokeValidateSsisProject.ps1
+++ b/Functions/InvokeValidateSsisProject.ps1
@@ -16,8 +16,8 @@ Edit-SsisEnvironmentName
 }
 This assumes you have run "unpublish-environmentReference" and "edit-ssisEnvironmentName" prior to deployment
 I am not a huge fan of roling back, but the functionality exists in this module if people want to use it.
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -32,7 +32,7 @@ $validationStatus = Invoke-ValidateSsisProject -ssisPublishFilePath $thisSsisPub
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -42,7 +42,7 @@ $validationStatus = Invoke-ValidateSsisProject -ssisPublishFilePath $thisSsisPub
         [Parameter(Position = 4, mandatory = $false)]
         [string] $ssisEnvironmentName)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/PublishSsisEnvironment.ps1
+++ b/Functions/PublishSsisEnvironment.ps1
@@ -7,8 +7,8 @@ If it doesn't exist, publish environment
 Before we can publish variables and environment references, we will need to create an environment
 uses publish json file to get values required
 Non-mandatory params here can be used to overwrite the values stored in the publish json file passed in
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -26,8 +26,8 @@ Publish-SsisEnvironment -ssisPublishFilePath $thisSsisPublishFilePath -sqlConnec
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Position = 0, mandatory = $false)]
-        [string] $ssisPublishFilePath,
+        [Parameter(Position = 0, mandatory = $true)]
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -37,7 +37,7 @@ Publish-SsisEnvironment -ssisPublishFilePath $thisSsisPublishFilePath -sqlConnec
         [Parameter(Position = 4, mandatory = $false)]
         [String] $ssisEnvironmentDescription)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/PublishSsisEnvironmentReference.ps1
+++ b/Functions/PublishSsisEnvironmentReference.ps1
@@ -7,8 +7,8 @@ Create a reference between an environment and a project
 We can then associate variables in an environment to parameters in a project
 Non-mandatory params here can be used to overwrite the values stored in the publish json file passed in
 It will verify that it is created.
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -23,7 +23,7 @@ Publish-SsisEnvironmentReference -ssisPublishFilePath $thisSsisPublishFilePath -
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -33,7 +33,7 @@ Publish-SsisEnvironmentReference -ssisPublishFilePath $thisSsisPublishFilePath -
         [Parameter(Position = 4, mandatory = $false)]
         [String] $ssisProjectName)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/PublishSsisFolder.ps1
+++ b/Functions/PublishSsisFolder.ps1
@@ -6,8 +6,8 @@ Create a catalog folder
 If not exists, create a catalog folder
 We will then be ableto deploy projects and environments
 Non-mandatory params here can be used to overwrite the values stored in the publish json file passed in
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -19,13 +19,13 @@ Publish-SsisFolder -ssisPublishFilePath $thisSsisPublishFilePath -sqlConnection 
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
         [String] $ssisFolderName)
 
-    Measure-Command {$ssisJson = Import-Json -path $ssisPublishFilePath}
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/PublishSsisIspac.ps1
+++ b/Functions/PublishSsisIspac.ps1
@@ -7,8 +7,8 @@ Publish an ispac and check that it was deployed.
 $ispacToDeploy is a file path.
 We convert into bits and pass in.
 Non-mandatory params here can be used to overwrite the values stored in the publish json file passed in
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ispacToDeploy
@@ -26,7 +26,7 @@ Publish-SsisIspac -ssisPublishFilePath $thisSsisPublishFilePath -sqlConnection $
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $true)]
@@ -35,7 +35,7 @@ Publish-SsisIspac -ssisPublishFilePath $thisSsisPublishFilePath -sqlConnection $
         [String] $ssisFolderName,
         [Parameter(Position = 4, mandatory = $false)]
         [string] $ssisProjectName)
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/PublishSsisVariables.ps1
+++ b/Functions/PublishSsisVariables.ps1
@@ -17,8 +17,8 @@ Functionality to create/alter are in separate functions:
     set-environmentvariableproperty
     set-environmentvariableprotection
     set-environmentvariablevalue
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -38,7 +38,7 @@ Non-mandatory params here can be used to overwrite the values stored in the publ
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -51,7 +51,7 @@ Non-mandatory params here can be used to overwrite the values stored in the publ
         [Switch] $localVariables,
         [Parameter(Position = 6, mandatory = $false)]
         [Switch] $whatIf)
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/TestVariablesForPublishProfile.ps1
+++ b/Functions/TestVariablesForPublishProfile.ps1
@@ -6,11 +6,11 @@ function Test-VariablesForPublishProfile {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
-        $ssisPublishFilePath
+        [Parameter(Position = 0, mandatory = $true)]
+        [PSCustomObject] $jsonPsCustomObject
     )
     $missingVariables = @()
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $keys = $($ssisJson.ssisEnvironmentVariable)
     foreach ($var in $keys) {
         $varName = $var.VariableName

--- a/Functions/UnpublishSsisDeployment.ps1
+++ b/Functions/UnpublishSsisDeployment.ps1
@@ -5,8 +5,8 @@ Rollback ispac deployment: reverts to previous version of deployed project.
 .Description
 If a validate project has failed and we wish to rollback we needto revert to previous working project
 First it checks that you can rollback (ie previous versions are stored)
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -32,7 +32,7 @@ Unpublish-SsisDeployment -ssisPublishFilePath $thisSsisPublishFilePath -sqlConne
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -44,7 +44,7 @@ Unpublish-SsisDeployment -ssisPublishFilePath $thisSsisPublishFilePath -sqlConne
         [Parameter(Position = 5, mandatory = $false)]
         [Switch] $delete)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName

--- a/Functions/UnpublishSsisEnvironmentReference.ps1
+++ b/Functions/UnpublishSsisEnvironmentReference.ps1
@@ -7,8 +7,8 @@ We may wish to remove a reference between an environment and a project.
 This function will check if an environment reference exists, and if it does, it will delete it.
 Non-mandatory params here can be used to overwrite the values stored in the publish json file passed in
 It will verify that it is deleted.
-.Parameter ssisPublishFilePath
-Filepath of json file containing the project parameters (eg Project Folder Name, Project Environment Name)
+.Parameter jsonPsCustomObject
+Tested json object loaded from Import-Json
 .Parameter sqlConnection
 The SQL Connection to SSISDB
 .Parameter ssisFolderName
@@ -23,7 +23,7 @@ Unpublish-SsisEnvironmentReference -ssisPublishFilePath $thisSsisPublishFilePath
     [CmdletBinding()]
     param(
         [Parameter(Position = 0, mandatory = $true)]
-        [string] $ssisPublishFilePath,
+        [PSCustomObject] $jsonPsCustomObject,
         [Parameter(Position = 1, mandatory = $true)]
         [System.Data.SqlClient.SqlConnection] $sqlConnection,
         [Parameter(Position = 2, mandatory = $false)]
@@ -33,7 +33,7 @@ Unpublish-SsisEnvironmentReference -ssisPublishFilePath $thisSsisPublishFilePath
         [Parameter(Position = 4, mandatory = $false)]
         [String] $ssisProjectName)
 
-    $ssisJson = Import-Json -path $ssisPublishFilePath
+    $ssisJson = $jsonPsCustomObject
     $ssisProperties = New-IscProperties -jsonObject $ssisJson
     if ($ssisFolderName) {
         $ssisProperties = Set-IscProperty -iscProperties $ssisProperties -newSsisFolderName $ssisFolderName


### PR DESCRIPTION
json object is now passed in as a PSCustomObject, instead of being created for each function. This should improve speed, but also allows us to test the json file before we even make a connection to the database. Test-Json can also be used by devs to validate json file before checking in.